### PR TITLE
Add explicit reference to node-sass as the dependency wasn't being loaded through nom install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "mocha": "^3.0.2",
+    "node-sass": "^4.1.1",
     "nodemon": "^1.10.2",
     "npm-run-all": "^3.0.0",
     "open": "0.0.5",


### PR DESCRIPTION
After cloning the webpack-npm-scripts-setup branch and running nom install, the start script wasn't functioning as the node-sass node module wasn't available. This manifested as errors in the output from npm start noting that node-sass wasn't available and the code rendered for bundle.js was the html markup, not the required js output.

To resolve this, I've added node-sass as a dev dependency in the packages.json file.

After adding the node-sass dev dependency, the process of cloning the repo, running npm install and then calling npm start works fine.