### PR TITLE
index.html extra line break in Windows

### DIFF
--- a/tools/buildHtml.js
+++ b/tools/buildHtml.js
@@ -6,7 +6,7 @@ const PROD = process.env.NODE_ENV === 'production';
 const baseDir = PROD ? 'build' : 'dist';
 
 fs.readFile('app/index.html', 'utf8', (err, markup) => {
-  const loadMarkup = cheerio.load(markup);
+  const loadMarkup = cheerio.load(markup, { decodeEntities: false });
   
   if (err) {
     return console.log(err);


### PR DESCRIPTION
In Windows buildHtml.js currently adds `&#xFEFF; ` above `<!DOCTYPE html>` (which adds a white gap above the header).

Issue and workaround discussed here https://github.com/cheeriojs/cheerio/issues/711

Awesome demo BTW really helped me do what I wanted thanks...